### PR TITLE
Update AppImageUpdaterBridge to QAppImageUpdate.

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,7 +197,7 @@ Although the AppImage format was carefully designed not to need any special supp
 
 ### Libraries
 
-- [AppImageUpdaterBridge](https://github.com/antony-jr/AppImageUpdaterBridge) - Qt5 library and plugin for updating AppImages, can be embedded into applications.
+- [QAppImageUpdate](https://github.com/antony-jr/QAppImageUpdate) - Qt5 library and plugin for updating AppImages, can be embedded into applications.
 - [AppImageServices](https://github.com/azubieta/AppImageServices) - D-Bus services providing a high-level interface over the AppImage manipulation libraries for file managers, software centers and other tools.
 - [libappimage](https://github.com/AppImage/libappimage) - Implements functionality for dealing with AppImage files, written in C++ using Boost.
 - [libzsync-go](https://github.com/AppImageCrafters/libzsync-go) - Zsync implementation written in Go that can be used to update AppImages.


### PR DESCRIPTION
As of v2x, The library is now called "QAppImageUpdate".