### PR TITLE
Added: Publish-AppImage for .NET

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,7 @@ Although the AppImage format was carefully designed not to need any special supp
 ### Deployment tools for .NET Core (Mono) applications
 
 - [.NET Core AppImage example](https://github.com/ppy/osu-deploy/blob/697a49e9602502a2b7a899c0dff5383f6512d5d2/Program.cs#L207-L243) - Example of how to deploy .NET Core (Mono) applications as an AppImage using `dotnet publish -f netcoreapp3.1 -r linux-x64` from within a `.cs` program.
+- [Publish-AppImage for .NET](https://github.com/kuiperzone/Publish-AppImage) - Calls dotnet publish on your project or solution and packages the output as an AppImage file (or zip) with a single command.
 
 ### Deployment tools for Flash applications
 


### PR DESCRIPTION
https://github.com/kuiperzone/Publish-AppImage

It should be added because a tool to simplify the creation of AppImage for .NET does not exist. This provides it.


Additionally (separately), suggest removal of:

[Get AppImage](https://www.srevinsaju.me/get-appimage/) 

Under "App catalogs", as the site redirects to unrelated content.